### PR TITLE
ci: don't fail if /builds already exists in linux Dockerfile

### DIFF
--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 LABEL maintainer="Mozilla Release Engineering <release+docker@mozilla.com>"
 
 # Add worker user
-RUN mkdir /builds && \
+RUN mkdir -p /builds && \
     adduser -h /builds/worker -s /bin/ash -D worker && \
     mkdir /builds/worker/artifacts && \
     chown worker:worker /builds/worker/artifacts

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache python3 py3-pip && \
     python3 -m pip install --no-cache --upgrade --break-system-packages pip setuptools
 
 # Setup other dependencies
-RUN apk add bash git
+RUN apk add bash git coreutils
 
 # %include-run-task
 


### PR DESCRIPTION
An upgrade to our image building tool kaniko introduced a change where VOLUME directories are automatically created. These directives get processed first, so the `RUN mkdir /builds` fails due to the directory already existing.