### PR TITLE
ci: switch to 'public_restricted' pull request strategy

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,7 +8,7 @@ version: 1
 reporting: checks-v1
 autoCancelPreviousChecks: true
 policy:
-    pullRequests: public
+    pullRequests: public_restricted
 tasks:
     - $let:
           trustDomain: "mozilla"


### PR DESCRIPTION
This will allow us to grant scopes to PRs based on whether the author is a collaborator or not. This is useful for protecting secrets from  the general public.